### PR TITLE
ページネーションを追加しました。一部デザインを変更しています

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,16 +10,17 @@ import {
 } from '@mui/material'
 import React from 'react'
 import { PokemonCard } from './components/PokemonCard'
-import { usePokemonList } from './api/pokemon'
+import { usePokemonList } from './api/pokemons-pagination'
 
 function App() {
   const [page, setPage] = React.useState(1)
   const itemsPerPage = 20
 
-  const { data, isLoading, error } = usePokemonList()
+  const { data, isLoading, error } = usePokemonList(page, itemsPerPage)
 
   const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value)
+    window.scrollTo(0, 0)
   }
 
   return (

--- a/frontend/src/api/pokemons-pagination.ts
+++ b/frontend/src/api/pokemons-pagination.ts
@@ -1,9 +1,9 @@
 import { PokemonListResponse } from '../types/pokemon'
 import { useQuery } from '@tanstack/react-query'
 
-export const fetchPokemonList = async (): Promise<PokemonListResponse> => {
+export const fetchPokemonList = async (page: number = 1, limit: number = 20): Promise<PokemonListResponse> => {
   try {
-    const response = await fetch(`http://localhost:8080/pokemons`, {
+    const response = await fetch(`http://localhost:8080/pokemons?page=${page}&limit=${limit}`, {
       headers: {
         'Accept': 'application/json',
       },
@@ -14,10 +14,10 @@ export const fetchPokemonList = async (): Promise<PokemonListResponse> => {
       throw new Error(`ネットワークエラーが発生しました: ${response.status} ${response.statusText}`)
     }
     
-    const pokemons = await response.json()
+    const data = await response.json()
     return {
-      count: pokemons.length,
-      results: pokemons
+      count: data.total,
+      results: data.pokemon
     }
   } catch (error) {
     if (error instanceof TypeError && error.message === 'Failed to fetch') {
@@ -27,9 +27,9 @@ export const fetchPokemonList = async (): Promise<PokemonListResponse> => {
   }
 }
 
-export const usePokemonList = () => {
+export const usePokemonList = (page: number = 1, limit: number = 20) => {
   return useQuery({
-    queryKey: ['pokemons'],
-    queryFn: fetchPokemonList,
+    queryKey: ['pokemons', page, limit],
+    queryFn: () => fetchPokemonList(page, limit),
   })
 } 

--- a/frontend/src/components/PokemonCard.tsx
+++ b/frontend/src/components/PokemonCard.tsx
@@ -7,19 +7,28 @@ interface Props {
 
 export const PokemonCard = ({ pokemon }: Props) => {
   return (
-    <Card>
+    <Card sx={{ width: 200, height: 280 }}>
       <CardContent>
         <Typography>
           No.{pokemon.id}
         </Typography>
-        <Typography variant="h6" component="h2" sx={{ textTransform: 'capitalize' }}>
+        <Typography 
+          variant="h6" 
+          component="h2" 
+          sx={{ 
+            textTransform: 'capitalize',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
           {pokemon.name}
         </Typography>
         <Box sx={{ textAlign: 'center', mt: 2 }}>
           <img 
             src={pokemon.image}
             alt={pokemon.name}
-            style={{ width: '80%', height: 'auto' }}
+            style={{ width: '120px', height: '120px', objectFit: 'contain' }}
           />
         </Box>
       </CardContent>


### PR DESCRIPTION
## PR 概要
GET /pokemons エンドポイントに ページネーション機能 を追加
クエリパラメータを取得できていない状態なのでこれを修正

## 変更内容
- バックエンドで作成したページネーションをフロントへ表示させる
- ポケモンカードの画面が崩れる不具合を修正
## webサイトの動作確認
https://github.com/user-attachments/assets/b2958dcf-adcc-4483-9aa2-bacd3ac4905f

