### PR TITLE
詳細表示を追加

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -11,6 +11,7 @@ import (
 const pokeAPIBaseURL = "https://pokeapi.co/api/v2"
 
 // 単体ポケモン取得処理
+// ブラウザからの要求を受け取り、ブラウザに要求されたものを返す
 func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -28,13 +29,43 @@ func getPokemonHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pokemon := Pokemon{
-		ID:    pokeResp.ID,
-		Name:  pokeResp.Name,
-		Image: pokeResp.Sprites.FrontDefault,
+	pokemonDetail := PokemonDetail{
+		ID:        pokeResp.ID,
+		Name:      pokeResp.Name,
+		Image:     pokeResp.Sprites.FrontDefault,
+		Height:    pokeResp.Height,
+		Weight:    pokeResp.Weight,
+		Types:     make([]string, len(pokeResp.Types)),
+		Abilities: make([]string, len(pokeResp.Abilities)),
+		Stats:     Stats{},
 	}
 
-	if err := json.NewEncoder(w).Encode(pokemon); err != nil {
+	for i, t := range pokeResp.Types {
+		pokemonDetail.Types[i] = t.Type.Name
+	}
+
+	for i, a := range pokeResp.Abilities {
+		pokemonDetail.Abilities[i] = a.Ability.Name
+	}
+
+	for _, s := range pokeResp.Stats {
+		switch s.Stat.Name {
+		case "hp":
+			pokemonDetail.Stats.HP = s.BaseStat
+		case "attack":
+			pokemonDetail.Stats.Attack = s.BaseStat
+		case "defense":
+			pokemonDetail.Stats.Defense = s.BaseStat
+		case "special-attack":
+			pokemonDetail.Stats.SpecialAttack = s.BaseStat
+		case "special-defense":
+			pokemonDetail.Stats.SpecialDefense = s.BaseStat
+		case "speed":
+			pokemonDetail.Stats.Speed = s.BaseStat
+		}
+	}
+
+	if err := json.NewEncoder(w).Encode(pokemonDetail); err != nil {
 		http.Error(w, "JSONエンコードエラー", http.StatusInternalServerError)
 		return
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ func main() {
 	r := mux.NewRouter()
 
 	// エンドポイント
+	//pokemon/{id}というパスを持つURLが入力された時だけ、getPokemonHandlerという関数を呼び出すということを明示しているのか？
 	r.HandleFunc("/pokemon/{id}", getPokemonHandler).Methods("GET")
 	r.HandleFunc("/pokemons", getPokemonsHandler).Methods("GET")
 

--- a/backend/models.go
+++ b/backend/models.go
@@ -6,11 +6,6 @@ type Sprites struct {
 }
 
 // PokemonResponse はポケモンAPIのレスポンスを表します。
-type PokemonResponse struct {
-	ID      int     `json:"id"`
-	Name    string  `json:"name"`
-	Sprites Sprites `json:"sprites"`
-}
 
 // Pokemon はフロントエンド向けのデータ構造（単体用・複数用で共通利用）。
 type Pokemon struct {
@@ -28,4 +23,51 @@ type PokemonListResponse struct {
 		Name string `json:"name"`
 		URL  string `json:"url"`
 	} `json:"results"`
+}
+
+// PokemonDetail はポケモンの詳細情報を表します。
+type PokemonDetail struct {
+	ID        int      `json:"id"`
+	Name      string   `json:"name"`
+	Image     string   `json:"image"`
+	Height    int      `json:"height"`
+	Weight    int      `json:"weight"`
+	Types     []string `json:"types"`
+	Abilities []string `json:"abilities"`
+	Stats     Stats    `json:"stats"`
+}
+
+// Stats はポケモンのステータス情報を表します。
+type Stats struct {
+	HP             int `json:"hp"`
+	Attack         int `json:"attack"`
+	Defense        int `json:"defense"`
+	SpecialAttack  int `json:"special_attack"`
+	SpecialDefense int `json:"special_defense"`
+	Speed          int `json:"speed"`
+}
+
+// PokemonResponse はポケモンAPIのレスポンスを表します。
+type PokemonResponse struct {
+	ID      int     `json:"id"`
+	Name    string  `json:"name"`
+	Height  int     `json:"height"`
+	Weight  int     `json:"weight"`
+	Sprites Sprites `json:"sprites"`
+	Types   []struct {
+		Type struct {
+			Name string `json:"name"`
+		} `json:"type"`
+	} `json:"types"`
+	Abilities []struct {
+		Ability struct {
+			Name string `json:"name"`
+		} `json:"ability"`
+	} `json:"abilities"`
+	Stats []struct {
+		Stat struct {
+			Name string `json:"name"`
+		} `json:"stat"`
+		BaseStat int `json:"base_stat"`
+	} `json:"stats"`
 }


### PR DESCRIPTION
## やったこと

- main.go, handlers.go, modesl.goに詳細表示の機能を追加

## できるようになったこと　(ユーザ目線)

- ポケモンのID、名前、画像、タイプ、特性、ステータスなどの情報を取得できる

## 動作確認 (postman)


- 詳細表示
<img width="1440" alt="スクリーンショット 2025-03-21 8 59 14" src="https://github.com/user-attachments/assets/31ce885a-87c8-4fc8-b69e-28ed16f0ec4d" /> 
- ページネーション
<img width="1440" alt="スクリーンショット 2025-03-21 8 59 14" src="https://github.com/user-attachments/assets/d55b4aa0-89f0-4400-bcea-c0ab1b41de4d" />

